### PR TITLE
add insecure skip verify option on clickhouse tls connection

### DIFF
--- a/deploy/helm/kubenetmon-server/templates/configMap.yaml
+++ b/deploy/helm/kubenetmon-server/templates/configMap.yaml
@@ -26,3 +26,4 @@ data:
     clickhouse_wait_for_async_insert: {{ .Values.inserter.waitForAsyncInsert }}
     clickhouse_skip_ping: {{ .Values.inserter.skipPing }}
     clickhouse_disable_tls: {{ .Values.inserter.disableTLS }}
+    clickhouse_insecure_skip_verify: {{ .Values.inserter.insecureSkipVerify }}

--- a/deploy/helm/kubenetmon-server/values.yaml
+++ b/deploy/helm/kubenetmon-server/values.yaml
@@ -71,6 +71,8 @@ inserter:
   skipPing: false
   # Disable TLS to ClickHouse. This is useful for testing.
   disableTLS: false
+  # setup insecure skip verify on TLS connection. Useful on TLS connection intern to clickhouse
+  insecureSkipVerify: false
 
 deployment:
   replicaCount: 3

--- a/pkg/inserter/inserter.go
+++ b/pkg/inserter/inserter.go
@@ -52,6 +52,8 @@ type ClickHouseOptions struct {
 	SkipPing bool
 	// Disable TLS on ClickHouse connection.
 	DisableTLS bool
+	// Allow TLS with unverified certificates
+	InsecureSkipVerify bool
 }
 
 // Observation is a conntrack observation from kubenetmon-agent labeled by the
@@ -132,7 +134,7 @@ func createClickHouseConnectionWithOptions(ctx context.Context, clickhouseOption
 	}
 	// Configure TLS if need be.
 	if !clickhouseOptions.DisableTLS {
-		options.TLS = &tls.Config{}
+		options.TLS = &tls.Config{InsecureSkipVerify: clickhouseOptions.InsecureSkipVerify}
 	}
 
 	conn, err := clickhouse.Open(&options)


### PR DESCRIPTION
This is an update to add option to ignore TLS certificat verification as asked here: https://github.com/ClickHouse/kubenetmon/issues/19