### PR TITLE
Respect database config when inserting data (was always using default)

### DIFF
--- a/pkg/inserter/inserter.go
+++ b/pkg/inserter/inserter.go
@@ -94,6 +94,7 @@ func NewInserter(clickhouseOptions ClickHouseOptions, runtimeInfo RuntimeInfo, n
 		w := worker{
 			waitAsyncInsert:      clickhouseOptions.WaitForAsyncInsert,
 			conn:                 conn,
+			database:             clickhouseOptions.Database,
 			batch:                make([]string, 0, clickhouseOptions.BatchSize),
 			batchExpirationTimer: time.NewTimer(clickhouseOptions.BatchSendTimeout),
 			batchSendTimeout:     clickhouseOptions.BatchSendTimeout,

--- a/pkg/inserter/worker.go
+++ b/pkg/inserter/worker.go
@@ -72,6 +72,7 @@ type worker struct {
 
 	waitAsyncInsert        bool
 	conn                   driver.Conn
+	database               string
 	batch                  []string
 	batchCreationTimestamp time.Time
 	batchExpirationTimer   *time.Timer
@@ -246,44 +247,44 @@ func (w *worker) flush() error {
 	}()
 
 	ctx := clickhouse.Context(context.Background(), clickhouse.WithSettings(clickhouse.Settings{"insert_deduplication_token": uuid.New().String()}))
-	q := `
-INSERT INTO default.network_flows_0
+	q := fmt.Sprintf(`
+INSERT INTO %s.network_flows_0
 (
-	date,
-	intervalStartTime,
-	intervalSeconds,
-	environment,
-	proto,
-	connectionClass,
-	connectionFlags,
-	direction,
-	localCloud,
-	localRegion,
-	localCluster,
-	localAvailabilityZone,
-	localNode, 
-	localInstanceID,
-	localNamespace,
-	localPod,
-	localIPv4,
-	localPort,
-	localApp,
-	remoteCloud,
-	remoteRegion,
-	remoteCluster,
-	remoteAvailabilityZone,
-	remoteNode,
-	remoteInstanceID,
-	remoteNamespace,
-	remotePod,
-	remoteIPv4,
-	remotePort,
-	remoteApp,
-	remoteCloudService,
-	bytes,
-	packets
+date,
+intervalStartTime,
+intervalSeconds,
+environment,
+proto,
+connectionClass,
+connectionFlags,
+direction,
+localCloud,
+localRegion,
+localCluster,
+localAvailabilityZone,
+localNode, 
+localInstanceID,
+localNamespace,
+localPod,
+localIPv4,
+localPort,
+localApp,
+remoteCloud,
+remoteRegion,
+remoteCluster,
+remoteAvailabilityZone,
+remoteNode,
+remoteInstanceID,
+remoteNamespace,
+remotePod,
+remoteIPv4,
+remotePort,
+remoteApp,
+remoteCloudService,
+bytes,
+packets
 )
-VALUES ` + strings.Join(w.batch, ", ")
+VALUES %s`, w.database, strings.Join(w.batch, ", "))
 	if err1 := w.conn.AsyncInsert(ctx, q, w.waitAsyncInsert); err1 != nil {
 		insertRetryCounter.Inc()
 		log.Err(err1).Msg("failed to insert, going to retry")


### PR DESCRIPTION
Hey team 👋

First off : huge thanks for ClickHouse and kubenetmon maintainers 🙏  

---

### Context

In our setup, we’re running **a single shared ClickHouse cluster** dedicated to kubenetmon.  
This cluster is shared across roughly a **dozen EKS clusters**, and each EKS cluster writes to **its own database** (one DB per cluster).  
This lets us isolate data and manage permissions cleanly : each kubenetmon instance has `INSERT` rights only on its own DB.

---

### The issue

Currently, even if the `database` field is set in the configuration, the `worker.flush()` function [always writes](https://github.com/ClickHouse/kubenetmon/blob/main/pkg/inserter/worker.go#L250) to:

```sql
INSERT INTO default.network_flows_0 (...)
```
So all inserts end up in the default database, regardless of what was configured.
In our case, that meant the service tried to write into DBs it didn’t have permissions for, causing errors like:
```
code: 497, message: Not enough privileges. To execute this query, it's necessary to have the grant INSERT(...) ON <db>.network_flows_0
```

---

### 🧩 This PR in a nutshell

- Passes the configured `Database` value from `ClickHouseOptions` into each `worker`
- Updates `worker.flush()` to dynamically use that database instead of hardcoding `default`

So instead of:

`INSERT INTO default.network_flows_0 (...)`

we now correctly get:

`INSERT INTO my_cluster_db.network_flows_0 (...)`

---

### ✅ Result

- Enables running **multiple kubenetmon instances** across many EKS clusters, all writing safely to a shared ClickHouse deployment  
- Prevents privilege errors when users are restricted to their own database  
- Makes the `database` configuration field actually effective (previously ignored?)

---

### 🛠 Notes

To stay robust, the PR uses `fmt.Sprintf` for building the query string.  
If needed, we could add identifier quoting (backticks) or validation to handle special DB names safely.