### PR TITLE
fix(test): wait for ClickHouse to accept connections before running queries

### DIFF
--- a/test/test-kind.sh
+++ b/test/test-kind.sh
@@ -30,6 +30,21 @@ echo "Waiting for ClickHouse pod to be ready..."
 kubectl wait --namespace default --for=condition=ready pod -l app=clickhouse --timeout=120s
 clickhouse_pod=$(kubectl get pods -l app=clickhouse -o jsonpath="{.items[0].metadata.name}")
 
+# Wait for ClickHouse to actually accept connections (pod readiness != server ready)
+echo "Waiting for ClickHouse to accept connections..."
+for i in $(seq 1 30); do
+    if kubectl exec -i "$clickhouse_pod" -- clickhouse-client --query="SELECT 1" >/dev/null 2>&1; then
+        echo "ClickHouse is ready!"
+        break
+    fi
+    if [ "$i" -eq 30 ]; then
+        echo "ClickHouse failed to accept connections after 30 attempts"
+        exit 1
+    fi
+    echo "Waiting for ClickHouse... (attempt $i/30)"
+    sleep 2
+done
+
 # Execute the SQL command
 kubectl exec -i "$clickhouse_pod" -- clickhouse-client --query="$(cat test/network_flows_0.sql)"
 


### PR DESCRIPTION
## Summary
- Fixes flaky CI failure in the `Test code` job where `clickhouse-client` fails with `Connection refused (localhost:9000)` immediately after `kubectl wait --for=condition=ready` returns
- Root cause: Kubernetes marks the ClickHouse pod as "Ready" before the server is actually listening on port 9000 (no readiness probe configured on the test deployment)
- Adds a retry loop (up to 30 attempts, 2s apart) that polls `clickhouse-client --query="SELECT 1"` to confirm ClickHouse is actually accepting connections before proceeding

## Test plan
- [x] Reproduced the failure scenario locally (CI logs show the race: pod ready -> immediate connection refused)
- [x] Ran `make integration-test` locally with the fix — test passes end-to-end
- [x] The retry loop correctly short-circuits on first success (no unnecessary waits when ClickHouse starts quickly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)